### PR TITLE
v0.5.7 update - instance-isolated identities

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,32 @@
 =============
 
 
+Changes for version 0.5.7
+=========================
+
+Minor Changes
+-------------
+
+-  Tests added to include checks for instance-isolated identities.
+
+
+Major Changes
+-------------
+
+-  ``reset_daemon()`` calls added to ``decrypt()``, ``verify()``, ``sign()``
+   & ``encrypt()``. This call kills the gpg-agent process & restarts it,
+   which in turn wipes the caching of secret keys available on the system
+   without a passphrase. This is crucial for users of applications with
+   multiple GnuPG objects that handle separate key identities. That's
+   because these methods will now throw ``PermissionError`` or ``LookupError``
+   if a private key operation is needed from an instance which is already
+   assigned to another private key in the keyring. This gives some important
+   anonymity protections to users.
+-  More improvements to error reporting.
+
+
+
+
 Changes for version 0.5.6
 =========================
 

--- a/README.rst
+++ b/README.rst
@@ -382,6 +382,32 @@ After a user no longer considers a key useful, or wants to dissociate from the k
 =============
 
 
+Changes for version 0.5.7
+=========================
+
+Minor Changes
+-------------
+
+-  Tests added to include checks for instance-isolated identities.
+
+
+Major Changes
+-------------
+
+-  ``reset_daemon()`` calls added to ``decrypt()``, ``verify()``, ``sign()``
+   & ``encrypt()``. This call kills the gpg-agent process & restarts it,
+   which in turn wipes the caching of secret keys available on the system
+   without a passphrase. This is crucial for users of applications with
+   multiple GnuPG objects that handle separate key identities. That's
+   because these methods will now throw ``PermissionError`` or ``LookupError``
+   if a private key operation is needed from an instance which is already
+   assigned to another private key in the keyring. This gives some important
+   anonymity protections to users.
+-  More improvements to error reporting.
+
+
+
+
 Changes for version 0.5.6
 =========================
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.rst", "w+") as readme:
 setup(
     name="tiny_gnupg",
     license="GPLv3",
-    version="0.5.6",
+    version="0.5.7",
     description=description,
     long_description=long_description,
     url="https://github.com/rmlibre/tiny_gnupg",

--- a/tiny_gnupg.egg-info/PKG-INFO
+++ b/tiny_gnupg.egg-info/PKG-INFO
@@ -392,6 +392,32 @@ Description: tiny_gnupg - A small-as-possible solution for handling GnuPG ed2551
         =============
         
         
+        Changes for version 0.5.7
+        =========================
+        
+        Minor Changes
+        -------------
+        
+        -  Tests added to include checks for instance-isolated identities.
+        
+        
+        Major Changes
+        -------------
+        
+        -  ``reset_daemon()`` calls added to ``decrypt()``, ``verify()``, ``sign()``
+           & ``encrypt()``. This call kills the gpg-agent process & restarts it,
+           which in turn wipes the caching of secret keys available on the system
+           without a passphrase. This is crucial for users of applications with
+           multiple GnuPG objects that handle separate key identities. That's
+           because these methods will now throw ``PermissionError`` or ``LookupError``
+           if a private key operation is needed from an instance which is already
+           assigned to another private key in the keyring. This gives some important
+           anonymity protections to users.
+        -  More improvements to error reporting.
+        
+        
+        
+        
         Changes for version 0.5.6
         =========================
         

--- a/tiny_gnupg/__init__.py
+++ b/tiny_gnupg/__init__.py
@@ -8,6 +8,6 @@
 # All rights reserved.
 #
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"
 
 from .tiny_gnupg import GnuPG, run, __all__


### PR DESCRIPTION
This update adds automatic enforcement of instance identities, preventing one instance from using the gpg-agent cache to access secret keys which aren't associated to that instance's key. This check is enforced by the ``passphrase`` attribute. If a user creates instance identities with the same passphrase, then this check can be side-stepped.